### PR TITLE
poc: add get_token_on_behalf_of() to auth0-api-python

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,6 +2,121 @@
 
 This document provides examples for using the `auth0-api-python` package to validate Auth0 tokens in your API.
 
+## On Behalf Of Token Exchange
+
+Use `get_token_on_behalf_of()` when your API receives an `Auth0` access token for itself and needs
+to exchange it for another `Auth0` access token targeting a downstream API while preserving the same
+user identity. This is especially useful for `MCP` servers and other intermediary APIs that need to
+call downstream APIs on behalf of the user.
+
+The following example verifies the incoming access token for your API, exchanges it for a token for the downstream API, and then calls the downstream API with the exchanged token.
+
+```python
+import asyncio
+import httpx
+
+from auth0_api_python import ApiClient, ApiClientOptions
+
+async def exchange_on_behalf_of():
+    api_client = ApiClient(ApiClientOptions(
+        domain="your-tenant.auth0.com",
+        audience="https://mcp-server.example.com",
+        client_id="<AUTH0_CLIENT_ID>",
+        client_secret="<AUTH0_CLIENT_SECRET>"
+    ))
+
+    incoming_access_token = "incoming-auth0-access-token"
+
+    claims = await api_client.verify_access_token(access_token=incoming_access_token)
+
+    result = await api_client.get_token_on_behalf_of(
+        access_token=incoming_access_token,
+        audience="https://calendar-api.example.com",
+        scope="calendar:read calendar:write"
+    )
+
+    async with httpx.AsyncClient() as client:
+        downstream_response = await client.get(
+            "https://calendar-api.example.com/events",
+            headers={"Authorization": f"Bearer {result['access_token']}"}
+        )
+
+    downstream_response.raise_for_status()
+
+    return {
+        "user": claims["sub"],
+        "data": downstream_response.json(),
+    }
+
+asyncio.run(exchange_on_behalf_of())
+```
+
+> [!TIP] Production notes:
+> - Pass the raw access token to `get_token_on_behalf_of()`. Do not pass the full `Authorization` header or include the `Bearer ` prefix.
+> - Verify the incoming token for your API before exchanging it so your application rejects invalid or mis-targeted tokens early.
+> - The downstream `audience` must match an API identifier configured in your Auth0 tenant.
+> - `get_token_on_behalf_of()` only returns access-token-oriented fields. It does not expose `id_token` or `refresh_token`.
+
+In the current implementation, `get_token_on_behalf_of()` forwards the incoming access token as
+the [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693#section-2.1) `subject_token` and relies on Auth0 to handle any DPoP-specific behavior for that token.
+
+## Inspecting Delegation After Token Verification
+
+When a downstream API or `MCP` server receives an access token that may have been issued through
+delegation, it can verify the token first and then inspect the `act` claim to identify the current
+actor for authorization and the full delegation chain for audit or attribution.
+
+```python
+import asyncio
+import logging
+
+from auth0_api_python import (
+    ApiClient,
+    ApiClientOptions,
+    get_current_actor,
+    get_delegation_chain,
+)
+
+logger = logging.getLogger(__name__)
+
+async def inspect_delegated_token():
+    api_client = ApiClient(ApiClientOptions(
+        domain="your-tenant.auth0.com",
+        audience="https://calendar-api.example.com"
+    ))
+
+    access_token = "delegated-auth0-access-token"
+
+    claims = await api_client.verify_access_token(access_token=access_token)
+
+    current_actor = get_current_actor(claims)
+    delegation_chain = get_delegation_chain(claims)
+
+    if current_actor != "mcp_server_client_id":
+        raise PermissionError("unexpected actor")
+
+    logger.info(
+        "delegated request",
+        extra={
+            "user_sub": claims["sub"],
+            "current_actor": current_actor,
+            "delegation_chain": delegation_chain,
+        },
+    )
+
+    return {
+        "user_sub": claims["sub"],
+        "current_actor": current_actor,
+        "delegation_chain": delegation_chain,
+    }
+
+asyncio.run(inspect_delegated_token())
+```
+
+Only the outermost `act.sub` represents the current actor and should be used for authorization
+decisions. Nested `act` values represent prior actors and are better suited for logging, audit, or
+attribution.
+
 ## Bearer Authentication
 
 Bearer authentication is the standard OAuth 2.0 token authentication method.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,92 @@ except ApiError as e:
 
 More info: https://auth0.com/docs/authenticate/custom-token-exchange
 
+#### On Behalf Of Token Exchange
+
+Use `get_token_on_behalf_of()` when your API receives an `Auth0` access token for itself and needs
+to exchange it for another `Auth0` access token targeting a downstream API while preserving the
+same user identity. This is especially useful for `MCP` servers and other intermediary APIs that
+need to call downstream APIs on behalf of the user.
+
+The following example verifies the incoming access token for your API, exchanges it for a token for the downstream API, and then calls the downstream API with the exchanged token.
+
+```python
+import httpx
+
+async def handle_calendar_request(incoming_access_token: str):
+    await api_client.verify_access_token(access_token=incoming_access_token)
+
+    result = await api_client.get_token_on_behalf_of(
+        access_token=incoming_access_token,
+        audience="https://calendar-api.example.com",
+        scope="calendar:read calendar:write"
+    )
+
+    async with httpx.AsyncClient() as client:
+        downstream_response = await client.get(
+            "https://calendar-api.example.com/events",
+            headers={"Authorization": f"Bearer {result['access_token']}"}
+        )
+
+    downstream_response.raise_for_status()
+
+    return downstream_response.json()
+```
+
+The OBO wrapper reuses the existing RFC 8693 exchange support and fixes both token-type parameters
+to Auth0 access-token exchange. In the current implementation, the SDK forwards the incoming access
+token as the `subject_token` and relies on Auth0 to handle any DPoP-specific behavior for that token.
+The OBO result only includes access-token-oriented fields. It does not expose `id_token` or
+`refresh_token`.
+
+#### Inspecting Delegation After Token Verification
+
+When a downstream API or `MCP` server receives an access token that may have been issued through
+delegation, it can verify the token first and then inspect the `act` claim to identify the current
+actor for authorization and the full delegation chain for logging or audit.
+
+```python
+import logging
+
+from auth0_api_python import (
+    ApiClient,
+    ApiClientOptions,
+    get_current_actor,
+    get_delegation_chain,
+)
+
+logger = logging.getLogger(__name__)
+
+api_client = ApiClient(ApiClientOptions(
+    domain="<AUTH0_DOMAIN>",
+    audience="<AUTH0_AUDIENCE>",
+))
+
+async def authorize_delegated_request(access_token: str):
+    claims = await api_client.verify_access_token(access_token=access_token)
+
+    current_actor = get_current_actor(claims)
+    delegation_chain = get_delegation_chain(claims)
+
+    if current_actor != "mcp_server_client_id":
+        raise PermissionError("unexpected actor")
+
+    logger.info(
+        "delegated request",
+        extra={
+            "user_sub": claims["sub"],
+            "current_actor": current_actor,
+            "delegation_chain": delegation_chain,
+        },
+    )
+
+    return claims
+```
+
+Only the outermost `act.sub` represents the current actor and should be used for authorization
+decisions. Nested `act` values represent prior actors in the delegation chain and are better suited
+for logging, audit, or attribution.
+
 #### Requiring Additional Claims
 
 If your application demands extra claims, specify them with `required_claims`:

--- a/src/auth0_api_python/__init__.py
+++ b/src/auth0_api_python/__init__.py
@@ -5,6 +5,7 @@ A lightweight Python SDK for verifying Auth0-issued access tokens
 in server-side APIs, using Authlib for OIDC discovery and JWKS fetching.
 """
 
+from .act import get_current_actor, get_delegation_chain
 from .api_client import ApiClient
 from .cache import CacheAdapter, InMemoryCache
 from .config import ApiClientOptions
@@ -14,7 +15,11 @@ from .errors import (
     DomainsResolverError,
     GetTokenByExchangeProfileError,
 )
-from .types import DomainsResolver, DomainsResolverContext
+from .types import (
+    DomainsResolver,
+    DomainsResolverContext,
+    OnBehalfOfTokenResult,
+)
 
 __all__ = [
     "ApiClient",
@@ -26,5 +31,8 @@ __all__ = [
     "DomainsResolverContext",
     "DomainsResolverError",
     "GetTokenByExchangeProfileError",
+    "get_current_actor",
+    "get_delegation_chain",
     "InMemoryCache",
+    "OnBehalfOfTokenResult",
 ]

--- a/src/auth0_api_python/act.py
+++ b/src/auth0_api_python/act.py
@@ -1,0 +1,64 @@
+"""
+Helpers for working with the `act` claim on verified access token claims.
+"""
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from .errors import VerifyAccessTokenError
+
+INVALID_ACT_CLAIM_MESSAGE = "Invalid act claim"
+
+
+def get_current_actor(claims: Mapping[str, Any]) -> Optional[str]:
+    """
+    Return the current actor from the outermost `act.sub`, if present.
+
+    Only the outermost `act.sub` should be used for authorization decisions.
+    Nested `act` values represent prior actors and are informational.
+    """
+    if not isinstance(claims, Mapping):
+        raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+    act_claim = claims.get("act")
+    if act_claim is None:
+        return None
+
+    if not isinstance(act_claim, Mapping):
+        raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+    sub = act_claim.get("sub")
+    if not isinstance(sub, str) or not sub.strip():
+        raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+    return sub
+
+
+def get_delegation_chain(claims: Mapping[str, Any]) -> list[str]:
+    """
+    Return the delegation chain from newest actor to oldest actor.
+
+    The first entry is the current actor (outermost `act.sub`). Later entries are
+    prior actors from nested `act` values and are typically most useful for audit
+    and attribution.
+    """
+    if not isinstance(claims, Mapping):
+        raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+    current = claims.get("act")
+    if current is None:
+        return []
+
+    chain: list[str] = []
+    while current is not None:
+        if not isinstance(current, Mapping):
+            raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+        sub = current.get("sub")
+        if not isinstance(sub, str) or not sub.strip():
+            raise VerifyAccessTokenError(INVALID_ACT_CLAIM_MESSAGE)
+
+        chain.append(sub)
+        current = current.get("act")
+
+    return chain

--- a/src/auth0_api_python/api_client.py
+++ b/src/auth0_api_python/api_client.py
@@ -21,6 +21,7 @@ from .errors import (
     MissingRequiredArgumentError,
     VerifyAccessTokenError,
 )
+from .types import OnBehalfOfTokenResult
 from .utils import (
     calculate_jwk_thumbprint,
     fetch_jwks,
@@ -34,6 +35,7 @@ from .utils import (
 
 # Token Exchange constants
 TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"  # noqa: S105
+OBO_ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"  # noqa: S105
 MAX_ARRAY_VALUES_PER_KEY = 20  # DoS protection for extra parameter arrays
 
 # OAuth parameter denylist - parameters that cannot be overridden via extras
@@ -232,7 +234,7 @@ class ApiClient:
             http_url: The HTTP URL (required for DPoP, also used for MCD resolver context)
 
         Returns:
-            The decoded access token claims
+            The decoded access token claims, including `act` when present.
 
         Raises:
             MissingRequiredArgumentError: If required args are missing
@@ -412,7 +414,7 @@ class ApiClient:
             required_claims: Optional list of additional claim names that must be present
 
         Returns:
-            The decoded token claims if valid.
+            The decoded token claims if valid, including `act` when present.
 
         Raises:
             MissingRequiredArgumentError: If no token is provided.
@@ -794,7 +796,7 @@ class ApiClient:
             Dictionary containing:
             - access_token (str): The Auth0 access token
             - expires_in (int): Token lifetime in seconds
-            - expires_at (int): Unix timestamp when token expires
+            - expires_at (int): Absolute expiration time as a Unix timestamp in seconds, calculated by the SDK from expires_in
             - id_token (str, optional): OpenID Connect ID token
             - refresh_token (str, optional): Refresh token
             - scope (str, optional): Granted scopes
@@ -961,6 +963,64 @@ class ApiClient:
                 502,
                 exc
             )
+
+    async def get_token_on_behalf_of(
+        self,
+        access_token: str,
+        audience: str,
+        scope: Optional[str] = None,
+    ) -> OnBehalfOfTokenResult:
+        """
+        Exchange an Auth0 access token for another Auth0 access token targeting a downstream API
+        while acting on behalf of the same end user (OBO).
+
+        This is a convenience wrapper around get_token_by_exchange_profile() that fixes the
+        RFC 8693 token types for Auth0 access-token-to-access-token exchange.
+
+        Args:
+            access_token: The Auth0 access token to exchange
+            audience: Target API identifier for the exchanged access token
+            scope: Optional space-separated OAuth 2.0 scopes to request
+
+        Returns:
+            Dictionary containing:
+            - access_token (str): The exchanged Auth0 access token
+            - expires_in (int): Token lifetime in seconds
+            - expires_at (int): Absolute expiration time as a Unix timestamp in seconds, calculated by the SDK from expires_in
+            - scope (str, optional): Granted scopes
+            - token_type (str, optional): Token type (typically "Bearer")
+            - issued_token_type (str, optional): RFC 8693 issued token type identifier
+
+        Raises:
+            MissingRequiredArgumentError: If required parameters are missing
+            GetTokenByExchangeProfileError: If client credentials are not configured or validation fails
+            ApiError: If the token endpoint returns an error
+        """
+        if not audience:
+            raise MissingRequiredArgumentError("audience")
+
+        result = await self.get_token_by_exchange_profile(
+            subject_token=access_token,
+            subject_token_type=OBO_ACCESS_TOKEN_TYPE,
+            audience=audience,
+            scope=scope,
+            requested_token_type=OBO_ACCESS_TOKEN_TYPE,
+        )
+
+        obo_result: OnBehalfOfTokenResult = {
+            "access_token": result["access_token"],
+            "expires_in": result["expires_in"],
+            "expires_at": result["expires_at"],
+        }
+
+        if "scope" in result:
+            obo_result["scope"] = result["scope"]
+        if "token_type" in result:
+            obo_result["token_type"] = result["token_type"]
+        if "issued_token_type" in result:
+            obo_result["issued_token_type"] = result["issued_token_type"]
+
+        return obo_result
 
     # ===== Private Methods =====
 

--- a/src/auth0_api_python/config.py
+++ b/src/auth0_api_python/config.py
@@ -27,8 +27,10 @@ class ApiClientOptions:
         dpop_required: Whether DPoP is required (default: False, allows both Bearer and DPoP).
         dpop_iat_leeway: Leeway in seconds for DPoP proof iat claim (default: 30).
         dpop_iat_offset: Maximum age in seconds for DPoP proof iat claim (default: 300).
-        client_id: Required for get_access_token_for_connection and get_token_by_exchange_profile.
-        client_secret: Required for get_access_token_for_connection and get_token_by_exchange_profile.
+        client_id: Required for get_access_token_for_connection, get_token_by_exchange_profile,
+                   and get_token_on_behalf_of.
+        client_secret: Required for get_access_token_for_connection, get_token_by_exchange_profile,
+                       and get_token_on_behalf_of.
         timeout: HTTP timeout in seconds for token endpoint requests (default: 10.0).
     """
     def __init__(

--- a/src/auth0_api_python/types.py
+++ b/src/auth0_api_python/types.py
@@ -6,6 +6,19 @@ from collections.abc import Awaitable, Callable
 from typing import Optional, TypedDict, Union
 
 
+class ActClaim(TypedDict, total=False):
+    """
+    Actor claim carried by access tokens issued through delegation.
+
+    Attributes:
+        sub: The current actor for this step of the delegation chain.
+        act: The prior actor in the delegation chain, if present.
+    """
+
+    sub: str
+    act: "ActClaim"
+
+
 class DomainsResolverContext(TypedDict, total=False):
     """
     Context passed to domains resolver functions.
@@ -18,6 +31,27 @@ class DomainsResolverContext(TypedDict, total=False):
     request_url: Optional[str]
     request_headers: Optional[dict]
     unverified_iss: str
+
+
+class OnBehalfOfTokenResult(TypedDict, total=False):
+    """
+    Result returned from an On Behalf Of token exchange.
+
+    Attributes:
+        access_token: The access token issued for the downstream API.
+        expires_in: Token lifetime in seconds.
+        expires_at: Absolute expiration time as a Unix timestamp in seconds, calculated by the SDK from expires_in.
+        scope: Granted scopes, if returned by Auth0.
+        token_type: Token type, if returned by Auth0.
+        issued_token_type: RFC 8693 issued token type, if returned by Auth0.
+    """
+
+    access_token: str
+    expires_in: int
+    expires_at: int
+    scope: str
+    token_type: str
+    issued_token_type: str
 
 DomainsResolver = Callable[
     [DomainsResolverContext], Union[list[str], Awaitable[list[str]]]

--- a/tests/test_act.py
+++ b/tests/test_act.py
@@ -1,0 +1,58 @@
+import pytest
+
+from auth0_api_python import get_current_actor, get_delegation_chain
+from auth0_api_python.errors import VerifyAccessTokenError
+
+INVALID_ACT_CLAIM_MESSAGE = "Invalid act claim"
+
+
+def test_get_current_actor_returns_none_when_act_is_missing():
+    claims = {"sub": "auth0|user123"}
+
+    assert get_current_actor(claims) is None
+    assert get_delegation_chain(claims) == []
+
+
+def test_get_current_actor_and_delegation_chain_from_nested_act():
+    claims = {
+        "sub": "auth0|user123",
+        "act": {
+            "sub": "mcp_server_2_client_id",
+            "act": {
+                "sub": "mcp_server_1_client_id",
+                "act": {
+                    "sub": "spa_client_id",
+                },
+            },
+        },
+    }
+
+    assert get_current_actor(claims) == "mcp_server_2_client_id"
+    assert get_delegation_chain(claims) == [
+        "mcp_server_2_client_id",
+        "mcp_server_1_client_id",
+        "spa_client_id",
+    ]
+
+
+def test_get_current_actor_rejects_blank_actor_subject():
+    with pytest.raises(
+        VerifyAccessTokenError,
+        match=INVALID_ACT_CLAIM_MESSAGE,
+    ):
+        get_current_actor({"act": {"sub": "   "}})
+
+
+def test_get_delegation_chain_rejects_invalid_nested_act():
+    with pytest.raises(
+        VerifyAccessTokenError,
+        match=INVALID_ACT_CLAIM_MESSAGE,
+    ):
+        get_delegation_chain(
+            {
+                "act": {
+                    "sub": "mcp_server_client_id",
+                    "act": "spa_client_id",
+                },
+            }
+        )

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -19,6 +19,7 @@ from conftest import (
 from freezegun import freeze_time
 from pytest_httpx import HTTPXMock
 
+from auth0_api_python import get_current_actor, get_delegation_chain
 from auth0_api_python.api_client import MAX_ARRAY_VALUES_PER_KEY, ApiClient
 from auth0_api_python.config import ApiClientOptions
 from auth0_api_python.errors import (
@@ -111,6 +112,68 @@ async def test_verify_access_token_successfully(httpx_mock: HTTPXMock):
     # 5) Verify the token
     claims = await api_client.verify_access_token(access_token=access_token)
     assert claims["sub"] == "user_123"
+
+
+@pytest.mark.asyncio
+async def test_verify_access_token_preserves_act_claim(httpx_mock: HTTPXMock):
+    """
+    Test that verified access token claims expose the act claim for OBO delegation.
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url=DISCOVERY_URL,
+        json={
+            "issuer": "https://auth0.local/",
+            "jwks_uri": JWKS_URL
+        }
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=JWKS_URL,
+        json={
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "kid": "TEST_KEY",
+                    "n": "whYOFK2Ocbbpb_zVypi9SeKiNUqKQH0zTKN1-6fpCTu6ZalGI82s7XK3tan4dJt90ptUPKD2zvxqTzFNfx4HHHsrYCf2-FMLn1VTJfQazA2BvJqAwcpW1bqRUEty8tS_Yv4hRvWfQPcc2Gc3-_fQOOW57zVy-rNoJc744kb30NjQxdGp03J2S3GLQu7oKtSDDPooQHD38PEMNnITf0pj-KgDPjymkMGoJlO3aKppsjfbt_AH6GGdRghYRLOUwQU-h-ofWHR3lbYiKtXPn5dN24kiHy61e3VAQ9_YAZlwXC_99GGtw_NpghFAuM4P1JDn0DppJldy3PGFC0GfBCZASw",
+                    "e": "AQAB",
+                    "alg": "RS256",
+                    "use": "sig"
+                }
+            ]
+        }
+    )
+
+    access_token = await generate_token(
+        domain="auth0.local",
+        user_id="user_123",
+        audience="my-audience",
+        issuer=None,
+        iat=True,
+        exp=True,
+        claims={
+            "act": {
+                "sub": "mcp_server_client_id",
+                "act": {
+                    "sub": "spa_client_id",
+                },
+            },
+        },
+    )
+
+    api_client = ApiClient(
+        ApiClientOptions(domain="auth0.local", audience="my-audience")
+    )
+
+    claims = await api_client.verify_access_token(access_token=access_token)
+
+    assert claims["sub"] == "user_123"
+    assert claims["act"]["sub"] == "mcp_server_client_id"
+    assert get_current_actor(claims) == "mcp_server_client_id"
+    assert get_delegation_chain(claims) == [
+        "mcp_server_client_id",
+        "spa_client_id",
+    ]
 
 @pytest.mark.asyncio
 async def test_verify_access_token_fail_no_iss():
@@ -2779,6 +2842,208 @@ async def test_get_token_by_exchange_profile_custom_timeout_honored(httpx_mock: 
     assert err.value.status_code == 504
 
 
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_missing_client_credentials():
+    """Test that OBO requires confidential client credentials."""
+    api_client = ApiClient(ApiClientOptions(
+        domain="auth0.local",
+        audience="my-audience",
+    ))
+
+    with pytest.raises(GetTokenByExchangeProfileError) as err:
+        await api_client.get_token_on_behalf_of(
+            access_token="token",
+            audience="https://api.backend.com"
+        )
+
+    assert "client credentials are required" in str(err.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_missing_audience(api_client_confidential):
+    """Test that OBO requires an explicit downstream audience."""
+    with pytest.raises(MissingRequiredArgumentError):
+        await api_client_confidential.get_token_on_behalf_of(
+            access_token="token",
+            audience=""
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_success(mock_discovery, api_client_confidential, httpx_mock):
+    """Test successful OBO exchange with fixed access-token types."""
+    httpx_mock.add_response(
+        method="POST",
+        url=TOKEN_ENDPOINT,
+        json={
+            "access_token": "obo-access-token",
+            "expires_in": 3600,
+            "scope": "read:data write:data",
+            "token_type": "Bearer",
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        }
+    )
+
+    result = await api_client_confidential.get_token_on_behalf_of(
+        access_token="incoming-access-token",
+        audience="https://api.backend.com",
+        scope="read:data write:data"
+    )
+
+    assert result["access_token"] == "obo-access-token"
+    assert result["expires_in"] == 3600
+    assert isinstance(result["expires_at"], int)
+    assert result["scope"] == "read:data write:data"
+    assert result["token_type"] == "Bearer"
+    assert result["issued_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+
+    assert_form_post(
+        httpx_mock,
+        expect_fields={
+            "grant_type": ["urn:ietf:params:oauth:grant-type:token-exchange"],
+            "subject_token": ["incoming-access-token"],
+            "subject_token_type": ["urn:ietf:params:oauth:token-type:access_token"],
+            "requested_token_type": ["urn:ietf:params:oauth:token-type:access_token"],
+            "audience": ["https://api.backend.com"],
+            "scope": ["read:data write:data"],
+        },
+        forbid_fields=["client_id", "client_secret"],
+        expect_basic_auth=("cid", "csecret")
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_preserves_inferred_expires_at(
+    api_client_confidential,
+    monkeypatch,
+):
+    """Test that OBO reuses the expires_at inferred by the generic exchange path."""
+
+    async def fake_exchange_profile(
+        *,
+        subject_token,
+        subject_token_type,
+        audience=None,
+        scope=None,
+        requested_token_type=None,
+        extra=None,
+    ):
+        assert subject_token == "incoming-access-token"
+        assert subject_token_type == "urn:ietf:params:oauth:token-type:access_token"
+        assert requested_token_type == "urn:ietf:params:oauth:token-type:access_token"
+        assert audience == "https://api.backend.com"
+        assert scope is None
+        assert extra is None
+
+        return {
+            "access_token": "obo-access-token",
+            "expires_in": 3600,
+            "expires_at": 1735693200,
+            "token_type": "Bearer",
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        }
+
+    monkeypatch.setattr(
+        api_client_confidential,
+        "get_token_by_exchange_profile",
+        fake_exchange_profile,
+    )
+
+    result = await api_client_confidential.get_token_on_behalf_of(
+        access_token="incoming-access-token",
+        audience="https://api.backend.com",
+    )
+
+    assert result["access_token"] == "obo-access-token"
+    assert result["expires_in"] == 3600
+    assert result["expires_at"] == 1735693200
+    assert result["token_type"] == "Bearer"
+    assert result["issued_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_without_scope(mock_discovery, api_client_confidential, httpx_mock):
+    """Test OBO exchange omits scope when not provided."""
+    httpx_mock.add_response(
+        method="POST",
+        url=TOKEN_ENDPOINT,
+        json=token_success(
+            access_token="obo-access-token",
+            issued_token_type="urn:ietf:params:oauth:token-type:access_token",
+            token_type="Bearer",
+        )
+    )
+
+    result = await api_client_confidential.get_token_on_behalf_of(
+        access_token="incoming-access-token",
+        audience="https://api.backend.com",
+    )
+
+    assert result["access_token"] == "obo-access-token"
+    assert "scope" not in last_form(httpx_mock)
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_does_not_expose_id_or_refresh_token(
+    mock_discovery, api_client_confidential, httpx_mock
+):
+    """Test OBO result only exposes access-token-oriented fields."""
+    httpx_mock.add_response(
+        method="POST",
+        url=TOKEN_ENDPOINT,
+        json={
+            "access_token": "obo-access-token",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            "id_token": "id-token",
+            "refresh_token": "refresh-token",
+        }
+    )
+
+    result = await api_client_confidential.get_token_on_behalf_of(
+        access_token="incoming-access-token",
+        audience="https://api.backend.com",
+    )
+
+    assert result["access_token"] == "obo-access-token"
+    assert "id_token" not in result
+    assert "refresh_token" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_api_error(mock_discovery, api_client_confidential, httpx_mock):
+    """Test that OBO reuses the existing exchange error semantics."""
+    httpx_mock.add_response(
+        method="POST",
+        url=TOKEN_ENDPOINT,
+        status_code=400,
+        json={
+            "error": "invalid_target",
+            "error_description": "The target API is not allowed"
+        }
+    )
+
+    with pytest.raises(ApiError) as err:
+        await api_client_confidential.get_token_on_behalf_of(
+            access_token="incoming-access-token",
+            audience="https://api.backend.com",
+        )
+
+    assert err.value.code == "invalid_target"
+    assert err.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_token_on_behalf_of_empty_access_token(api_client_confidential):
+    """Test that OBO validates the incoming access token via the shared exchange path."""
+    with pytest.raises(MissingRequiredArgumentError):
+        await api_client_confidential.get_token_on_behalf_of(
+            access_token="",
+            audience="https://api.backend.com",
+        )
+
+
 # ===== MCD (Multi-Custom Domain) Tests =====
 
 @pytest.mark.asyncio
@@ -4134,5 +4399,3 @@ async def test_mcd_verify_request_with_resolver_context(httpx_mock):
     assert ctx["request_headers"]["authorization"] == f"Bearer {token}"
     assert ctx["request_headers"]["x-custom-header"] == "test-value"
     assert ctx["unverified_iss"] == "https://tenant1.auth0.com/"
-
-


### PR DESCRIPTION
### Changes
Implemented `OBO` token exchange support in `auth0-api-python` by adding `ApiClient.get_token_on_behalf_of(...)` as a thin wrapper over the existing `RFC 8693` exchange flow. 

The new `API` keeps the application-facing contract simple by accepting only the incoming access token, downstream `audience`, and optional `scope`, while reusing the existing confidential-client authentication and token exchange behavior internally.

This PR also adds the exported `OBO` result type, targeted test coverage for the new method, and `README`/`examples` updates.

The change is additive and does not introduce breaking changes to the existing SDK surface.